### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,5 +1,8 @@
 name: PHP Composer
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/kachuru/zone/security/code-scanning/1](https://github.com/kachuru/zone/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function correctly. Based on the steps in the workflow, the `contents: read` permission is sufficient, as the workflow primarily involves checking out the code, setting up PHP, validating dependencies, caching, and running tests. None of these steps require write access to the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
